### PR TITLE
Adding bugs url and updating devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "connect-validation",
-  "description": "A middleware that provide addError and sendError response methods.",
+  "description": "A middleware that provides `addError()` and `sendError()` response methods.",
   "version": "0.1.0",
   "author": "Rémy Hubscher <rhubscher@mozilla.com>",
   "homepage": "https://github.com/mozilla-services/connect-validation/",
+  "bugs": "https://github.com/mozilla-services/connect-validation/issues/",
   "license" : "MPL-2.0",
   "repository": {
     "type": "git",
@@ -14,10 +15,10 @@
     "node": ">= 0.10.0"
   },
   "devDependencies": {
+    "chai": "1.9.x",
     "express": "3.x",
-    "mocha": "1.8.x",
-    "chai": "1.5.x",
     "jshint": "2.x",
+    "mocha": "1.18.x",
     "sinon": "1.9.x",
     "supertest": "0.10.x"
   },


### PR DESCRIPTION
Added 'bugs' URL to make the package.json validator a bit happier: http://package-json-validator.com/

Tweaked the 'description' slightly.

Updating devDependencies for Mocha and Chai.

> **Outdated Dev Dependencies**
> - mocha (package: 1.8.x, latest: 1.18.2)
> - chai (package: 1.5.x, latest: 1.9.1)
